### PR TITLE
Make main function generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 docs/build/
 env
 node_modules
+.vscode/

--- a/test/test-basic-test.jl
+++ b/test/test-basic-test.jl
@@ -3,28 +3,36 @@ using Random
 using CUDA
 using InclusiveScans
 
-@testset "InclusiveScans.jl Tests" begin
-    sizes = (1, 100, 1000, 25_000, 100_000)
+RNG = Xoshiro(137)  # Fixed seed
+SIZES = (1, 100, 1000, 25_000, 100_000)
+TYPES = (Float16, Float32, Float64, Int32, Int64, ComplexF32, ComplexF64)
 
-    for N in sizes
-        @testset "Test with N = $N" begin
-            rng = Xoshiro(137)  # Fixed seed
+_custom_eps(::Type{T}) where {T<:AbstractFloat} = sqrt(eps(T))
+_custom_eps(::Type{T}) where {T<:Integer} = zero(T)
+_custom_eps(::Type{Complex{T}}) where {T<:AbstractFloat} = sqrt(eps(T))
+
+@testset "InclusiveScans.jl Tests" begin
+    @testset "Test with T = $T" for T in TYPES
+        @testset "Test with N = $N" for N in SIZES
+            if (T == Float16 && N >= 10_000)
+                # precision of F16 is too little for large tests
+                continue
+            end
 
             # Generate random input
-            bit_input = BitVector(rand(rng, Bool, N))
-            float_input = Float32.(bit_input)
+            input = rand(RNG, T, N)
 
-            d_in = CuArray(float_input)
-            d_out = CUDA.zeros(Float32, N)
+            d_in = CuArray(input)
+            d_out = similar(d_in)
 
             # Run inclusive scan on GPU
             InclusiveScans.largeArrayScanInclusive!(d_out, d_in, Int32(N))
 
             h_out = Array(d_out)
-            h_check = Base.accumulate(+, float_input)
+            h_check = Base.accumulate(+, input)
 
             # Check if GPU result matches the CPU reference
-            @test isapprox(h_out, h_check; atol = eps(Float32))
+            @test isapprox(h_out, h_check, rtol = _custom_eps(T))
         end
     end
 end


### PR DESCRIPTION
I added some extra info:
- reasonable type information to function headers
- `@inbounds` macro
- some more `::Int32` constraints to make sure everything is actually an int32
- `always_inline = true` for CUDA kernel calls
These changes might improve performance, but I haven't benchmarked it properly yet.

I also made the function generic so it can be used with any type `T` that supports basic arithmetic. To reflect that, I made the tests generic, too, and now test over some Float, Integer, and Complex types.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [ ] I am following the [contributing guidelines](https://github.com/QEDjl-project/InclusiveScans.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
